### PR TITLE
Fix: CHCircleButton Image 중앙 안 맞는 문제

### DIFF
--- a/Chaap/Chaap/Common/Components/CHCircleButton.swift
+++ b/Chaap/Chaap/Common/Components/CHCircleButton.swift
@@ -36,10 +36,8 @@ struct CHCircleButton: View {
                 .frame(width: 44, height: 44)
         
             Image(systemName: buttonImageName)
-                .resizable()
-                .scaledToFit()
+                .font(.system(size: 20, weight: .medium))
                 .foregroundStyle(Color.chLabelWhitePrimary)
-                .frame(height: 20)
         }
     }
 }


### PR DESCRIPTION
## ✨ PR 유형

- [x] 버그 수정


## 🛠️ 작업내용
- 기존 프레임 고정 방식에서 font로 대체했습니다.